### PR TITLE
Add this.log() function to portal network class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ node_modules
 
 package-lock.json
 
-src/wire/Ultralight-UTP/
+dist

--- a/src/portalnetwork/client.ts
+++ b/src/portalnetwork/client.ts
@@ -256,9 +256,9 @@ export class PortalNetwork extends EventEmitter {
 
             case PacketType.ST_SYN: await this.uTP.handleIncomingSyn(packet, srcId); break;
             case PacketType.ST_DATA: await this.uTP.handleIncomingData(packet, srcId); break;
-            case PacketType.ST_STATE: log('got STATE packet'); break;
-            case PacketType.ST_RESET: log('got RESET packet'); break;
-            case PacketType.ST_FIN: await this.uTP.handleFin(packet, srcId); log('got FIN packet'); break;
+            case PacketType.ST_STATE: this.log('got STATE packet'); break;
+            case PacketType.ST_RESET: this.log('got RESET packet'); break;
+            case PacketType.ST_FIN: await this.uTP.handleFin(packet, srcId); this.log('got FIN packet'); break;
         }
     }
 


### PR DESCRIPTION
this.log(string | Union) will still print to the console, but now will also emit a "log" event with the same string, which will be used by a react component in the browser client.